### PR TITLE
Add support for Auxiliary Resources

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Pdsinterop\Solid\Resources;
+
+class Exception extends \Exception
+{
+    public static function create(string $error, array $context, \Exception $previous = null): Exception
+    {
+        return new static(vsprintf($error, $context), 0, $previous);
+    }
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -6,6 +6,6 @@ class Exception extends \Exception
 {
     public static function create(string $error, array $context, \Exception $previous = null): Exception
     {
-        return new static(vsprintf($error, $context), 0, $previous);
+        return new self(vsprintf($error, $context), 0, $previous);
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -103,7 +103,12 @@ class Server
 		}
 		$path = rawurldecode($path);
 
-		// @FIXME: The path can also come from a 'Slug' header
+        // The path can also come from a 'Slug' header
+        if ($path === '' && $request->hasHeader('Slug')) {
+            $slugs = $request->getHeader('Slug');
+            // @CHECKME: First set header wins, is this correct? Or should it be the last one?
+            $path = reset($slugs);
+        }
 
         $method = $this->getRequestMethod($request);
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -167,7 +167,7 @@ class Server
                 if ($method === 'HEAD') {
                     $response->getBody()->rewind();
                     $response->getBody()->write('');
-					$response = $response->withStatus("204"); // CHECKME: nextcloud will remove the updates-via header - any objections to give the 'HEAD' request a 'no content' response type?
+					$response = $response->withStatus(204); // CHECKME: nextcloud will remove the updates-via header - any objections to give the 'HEAD' request a 'no content' response type?
 					if ($this->pubsub) {
 						$response = $response->withHeader("updates-via", $this->pubsub);
 					}
@@ -177,7 +177,7 @@ class Server
             case 'OPTIONS':
                 $response = $response
                     ->withHeader('Vary', 'Accept')
-                    ->withStatus('204')
+                    ->withStatus(204)
                 ;
                 break;
 
@@ -204,7 +204,7 @@ class Server
 					$mimetype = self::MIME_TYPE_DIRECTORY;
 				}
 				if ($pathExists === true) {
-					if ($mimetype === self::MIME_TYPE_DIRECTORY) {
+					if (isset($mimetype) && $mimetype === self::MIME_TYPE_DIRECTORY) {
 						$contentType= explode(";", $request->getHeaderLine("Content-Type"))[0];
 						$slug = $request->getHeaderLine("Slug");
 						if ($slug) {
@@ -360,7 +360,7 @@ class Server
         } else {
             $success = false;
 
-            set_error_handler(static function($severity, $message, $filename, $line) {
+            set_error_handler(static function ($severity, $message, $filename, $line) {
                 throw new \ErrorException($message, 0, $severity, $filename, $line);
             });
 
@@ -538,7 +538,7 @@ class Server
 			$response->getBody()->write($contents);
 			$response = $response->withHeader("Content-type", "text/turtle");
 			$response = $response->withStatus(200);
-		} else if ($filesystem->has($path) === false) {
+		} elseif ($filesystem->has($path) === false) {
             $message = vsprintf(self::ERROR_PATH_DOES_NOT_EXIST, [$path]);
             $response->getBody()->write($message);
             $response = $response->withStatus(404);

--- a/src/Server.php
+++ b/src/Server.php
@@ -411,12 +411,17 @@ class Server
 				'Sec-WebSocket-Protocol' => 'solid-0.1'
 			)
 		));
-		$client->send("pub $baseUrl$path\n");
 
-		while ($path !== "/") {
-			$path = $this->parentPath($path);
-			$client->send("pub $baseUrl$path\n");
-		}
+        try {
+            $client->send("pub $baseUrl$path\n");
+
+            while ($path !== "/") {
+                $path = $this->parentPath($path);
+                $client->send("pub $baseUrl$path\n");
+            }
+        } catch (\WebSocket\Exception $exception) {
+            throw new Exception('Could not write to pub-sup server', 502, $exception);
+        }
 	}
 
     private function handleDeleteRequest(Response $response, string $path, $contents): Response

--- a/src/Server.php
+++ b/src/Server.php
@@ -212,9 +212,10 @@ class Server
 							$filename = $this->guid();
 						}
 						// FIXME: make this list complete for at least the things we'd expect (turtle, n3, jsonld, ntriples, rdf);
-						// FIXME: if no content type was passed, we should reject the request according to the spec;
-
 						switch ($contentType) {
+							case '':
+								// FIXME: if no content type was passed, we should reject the request according to the spec;
+							break;
 							case "text/plain":
 								$filename .= ".txt";
 							break;
@@ -607,11 +608,17 @@ class Server
 		foreach ($listContents as $item) {
 			switch($item['type']) {
 				case "file":
-					$filename = "<" . rawurlencode($item['basename']) . ">";
-					$turtle[$filename] = array(
-						"a" => array("ldp:Resource")
-					);
-					$turtle["<>"]['ldp:contains'][] = $filename;
+                    // ACL and meta files should not be listed in directory overview
+                    if (
+                        $item['basename'] !== '.meta'
+                        && in_array($item['extension'], ['acl', 'meta']) === false
+                    ) {
+                        $filename = "<" . rawurlencode($item['basename']) . ">";
+                        $turtle[$filename] = array(
+                            "a" => array("ldp:Resource")
+                        );
+                        $turtle["<>"]['ldp:contains'][] = $filename;
+                    }
 				break;
 				case "dir":
 					// FIXME: we have a trailing slash here to please the test suits, but it probably should also pass without it since we are a Container.

--- a/src/Server.php
+++ b/src/Server.php
@@ -6,7 +6,6 @@ use EasyRdf_Exception;
 use EasyRdf_Graph as Graph;
 use Laminas\Diactoros\ServerRequest;
 use League\Flysystem\FilesystemInterface as Filesystem;
-use LogicException;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Throwable;
@@ -147,8 +146,8 @@ class Server
             // @FIXME: Add correct headers to resources (for instance allow DELETE on a GET resource)
             // ->withAddedHeader('Accept-Patch', 'text/ldpatch')
             // ->withAddedHeader('Accept-Post', 'text/turtle, application/ld+json, image/bmp, image/jpeg')
-            // ->withHeader('Allow', 'GET, HEAD, OPTIONS, PATCH, POST, PUT');
-        // ;
+            // ->withHeader('Allow', 'GET, HEAD, OPTIONS, PATCH, POST, PUT')
+        //;
 
         switch ($method) {
             case 'DELETE':
@@ -249,8 +248,7 @@ class Server
 				}
 			break;
             default:
-                $message = vsprintf(self::ERROR_UNKNOWN_HTTP_METHOD, [$method]);
-                throw new LogicException($message);
+                throw Exception::create(self::ERROR_UNKNOWN_HTTP_METHOD, [$method]);
                 break;
         }
 
@@ -303,7 +301,7 @@ class Server
 										foreach ($values as $value) {
 											$count = $graph->delete($resource, $property, $value);
 											if ($count === 0) {
-												throw new \Exception("Could not delete a value", 500);
+												throw new Exception("Could not delete a value", 500);
 											}
 										}
 									}
@@ -311,7 +309,7 @@ class Server
 							}
 						break;
 						default:
-							throw new \Exception("Unimplemented SPARQL", 500);
+							throw new Exception("Unimplemented SPARQL", 500);
 						break;
 					}
 				}
@@ -500,6 +498,7 @@ class Server
     private function handleReadRequest(Response $response, string $path, $contents, $mime=''): Response
     {
 		$filesystem = $this->filesystem;
+
 		if ($path === "/") { // FIXME: this is a patch to make it work for Solid-Nextcloud; we should be able to just list '/';
 			$contents = $this->listDirectoryAsTurtle($path);
 			$response->getBody()->write($contents);
@@ -591,7 +590,7 @@ class Server
 					$turtle["<>"]['ldp:contains'][] = $filename;
 				break;
 				default:
-					throw new \Exception("Unknown type", 500);
+					throw new Exception("Unknown type", 500);
 				break;
 			}
 		}

--- a/src/example.php
+++ b/src/example.php
@@ -66,7 +66,10 @@ if (strpos($path, '/data/') === 0) {
 
     $response = $server->respondToRequest($request);
 } elseif ($target === 'GET/') {
-    $response->getBody()->write(getHomepage());
+    $fileHandle = fopen(__FILE__, 'rb');
+    fseek($fileHandle, __COMPILER_HALT_OFFSET__);
+    $homepage = stream_get_contents($fileHandle);
+    $response->getBody()->write($homepage);
 } else {
     $response = $response->withStatus(404);
     $response->getBody()->write("<h1>404</h1><p>Path '$path' does not exist.</p>");
@@ -85,17 +88,8 @@ foreach ($response->getHeaders() as $name => $values) {
     }
 }
 
-echo (string)  $response->getBody();
+echo (string) $response->getBody();
 exit;
-
-function getHomepage() : string
-{
-    $fileHandle = fopen(__FILE__, 'rb');
-
-    fseek($fileHandle, __COMPILER_HALT_OFFSET__);
-
-    return stream_get_contents($fileHandle);
-}
 
 __halt_compiler();<!doctype html>
 <html lang="en">

--- a/tests/fixtures/.acl
+++ b/tests/fixtures/.acl
@@ -1,0 +1,1 @@
+# Empty ACL file

--- a/tests/fixtures/file.ttl
+++ b/tests/fixtures/file.ttl
@@ -1,0 +1,6 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+</>
+    dc:title "Top-level Test document" ;
+    rdfs:comment "Dummy file for testing metadata file in same directory" .

--- a/tests/fixtures/nested/parent/child/file.ttl
+++ b/tests/fixtures/nested/parent/child/file.ttl
@@ -1,0 +1,6 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+</>
+    dc:title "Nested Test document" ;
+    rdfs:comment "Dummy file for testing metadata file in a parent directory" .


### PR DESCRIPTION
Currently the Server does not support [Auxiliary Resources](https://solidproject.org/TR/protocol#auxiliary-resources) as defined by the Solid Protocol<sup>1</sup>

This MR adds the majority of support. Support for Description Resource `rel="describes"` has not yet been added.<sup>2</sup>

It also contains some code cleanup for the up-and-coming QA tools that are to be added.

_Because of time constraints, this MR might be merged before review, with any changes based on comments added after the fact._


## Footnotes

1. Section **4.3** in version 0.9.0 (2021-12-17)
2. Section **4.3.2** in version 0.9.0 (2021-12-17)