### PR TITLE
fix nullable values

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,7 +4,7 @@ namespace Pdsinterop\Solid\Resources;
 
 class Exception extends \Exception
 {
-    public static function create(string $error, array $context, ?\Exception $previous): Exception
+    public static function create(string $error, array $context, ?\Exception $previous = null): Exception
     {
         return new self(vsprintf($error, $context), 0, $previous);
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,7 +4,7 @@ namespace Pdsinterop\Solid\Resources;
 
 class Exception extends \Exception
 {
-    public static function create(string $error, array $context, \Exception $previous = null): Exception
+    public static function create(string $error, array $context, ?\Exception $previous): Exception
     {
         return new self(vsprintf($error, $context), 0, $previous);
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -96,7 +96,7 @@ class Server
     //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
     // @TODO: The Graph should be injected by the caller
-    final public function __construct(Filesystem $filesystem, Response $response, Graph $graph = null)
+    final public function __construct(Filesystem $filesystem, Response $response, ?Graph $graph)
     {
         $this->basePath = '';
         $this->baseUrl = '';
@@ -588,6 +588,10 @@ class Server
 
     private function sendNotificationUpdate($path, $type)
     {
+        if (!isset($this->notifications)) {
+            return;
+        }
+
         $baseUrl = $this->baseUrl;
         $this->notifications->send($baseUrl . $path, $type);
 
@@ -788,7 +792,7 @@ class Server
                     // ACL and meta files should not be listed in directory overview
                     if (
                         $item['basename'] !== '.meta'
-                        && in_array($item['extension'], ['acl', 'meta']) === false
+                        && in_array($item['extension']??'', ['acl', 'meta']) === false
                     ) {
                         try {
                             $linkMetadataResponse = $this->handleLinkMetadata(clone $this->response, $item['path']);

--- a/src/Server.php
+++ b/src/Server.php
@@ -96,7 +96,7 @@ class Server
     //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
     // @TODO: The Graph should be injected by the caller
-    final public function __construct(Filesystem $filesystem, Response $response, ?Graph $graph)
+    final public function __construct(Filesystem $filesystem, Response $response, ?Graph $graph = null)
     {
         $this->basePath = '';
         $this->baseUrl = '';


### PR DESCRIPTION
This MR supercedes #28, which I merged before realising that the `=null` should not be removed, as that makes the optional parameter(s) required, breaking calls.

See https://www.php.net/manual/en/migration84.deprecated.php and 
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated